### PR TITLE
Pin versions until bokeh extension is updated for new jupyterlab release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN cd /tmp; \
 RUN jupyter serverextension enable --py jupyterlab \
     && jupyter nbextension enable --py widgetsnbextension \
     && jupyter labextension install \
-        @jupyter-widgets/jupyterlab-manager \
+        @jupyter-widgets/jupyterlab-manager@0.35.0 \
         jupyter-matplotlib \
         jupyterlab_bokeh \
         @pyviz/jupyterlab_pyviz \

--- a/root/tmp/requirements.txt
+++ b/root/tmp/requirements.txt
@@ -5,8 +5,8 @@ holoviews
 ipympl
 ipywidgets
 jupyter
-jupyterlab
-jupyterlab-widgets
+jupyterlab==0.32.1
+jupyterlab-widgets==0.6.15
 networkx
 numpy
 nxpd
@@ -19,4 +19,4 @@ seaborn
 sympy
 jupyter_contrib_nbextensions
 jupyter_nbextensions_configurator
-jupyterlab_github
+jupyterlab_github==0.6.0


### PR DESCRIPTION
* jupyterlab
* jupyterlab-widgets
* jupyterlab-githu
* jupyterlab-manager

Until jupyterlab_bokeh updates (see: https://github.com/bokeh/jupyterlab_bokeh/issues/47)