### PR TITLE
Better VCS integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rappdw/docker-python-node:p3.6.5-n8.11.3-slim-jessie
 
-COPY root/ /
+COPY root/tmp/requirements.txt /tmp/requirements.txt
 
 RUN cd /tmp; \
     pip install --no-cache-dir -r requirements.txt
@@ -27,6 +27,8 @@ ENV NB_USER=jovyan \
 # volumes=--mount type=bind,source={project_root},target=/home/jovyan/project
 
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER
+
+COPY root/ /
 
 CMD ["/usr/local/bin/start-notebook.sh"]
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-| Build |
-| ----- |
-| [![Build Status](https://img.shields.io/docker/automated/rappdw/docker-ds.svg)](https://hub.docker.com/r/rappdw/docker-ds/) |
+[![Build Status](https://img.shields.io/docker/automated/rappdw/docker-ds.svg)](https://hub.docker.com/r/rappdw/docker-ds/)
 
 # Docker Container for Data Science Notebooks
 
@@ -15,6 +13,13 @@ used as well as several jupyter extensions that are useful, including:
 * bokeh
 * seaborn
 * holoviews
+
+## VCS & Notebooks
+While the `.ipynb` files are json, comparing the raw file formats aren't ideal for diffing changes, etc. In order to
+better facilitate working with VCS, especially for human diff comprehension, this image support a jupyter save hook
+that converts a notebook into `.py` and `.html` files in a `.diffs` sub-directory. To enable this, pass the envrionment
+variable `DOCKER_DS_DIFFS=1` when starting the container. (See `run-notebook` command in 
+[docker-utils](https://github.com/rappdw/docker-utils))
 
 ## Credentials
 There are a number of credentials utlized by this container, including: notebook password, github plugin OAuth 

--- a/bin/build
+++ b/bin/build
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker build -t rappdw/docker-ds:cpu-only -f Dockerfile .
+docker build -t rappdw/docker-ds -f Dockerfile .

--- a/root/docker-entrypoint.sh
+++ b/root/docker-entrypoint.sh
@@ -12,4 +12,9 @@ elif [ -e /home/jovyan/project/setup.py ]; then
     pip install -e /home/jovyan/project
 fi
 
-exec su - jovyan "$@"
+HOME=/home/jovyan
+if [ -d "/home/jovyan/project" ]; then
+    exec su -m - jovyan -c "cd /home/jovyan/project; $@"
+else
+    exec su -m - jovyan -c "cd /home/jovyan; $@"
+fi


### PR DESCRIPTION
Save .py and .html versions of a notebook on save. Easier for human inspection of version differences. 

To enable, add -e DOCKER_DS_DIFFS=1 on `docker run`