### PR TITLE
removing the line "COPY root /" because it breaks apt-get in some situations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ RUN set -ex; \
     apt-get clean; \
     rm -rf /var/tmp/* /tmp/* /var/lib/apt/lists/*
 
-COPY root/ /
+COPY root/usr/local/bin /usr/local/bin
+COPY root/etc/jupyter /etc/jupyter
+COPY root/docker-entrypoint.sh /docker-entrypoint.sh
 
 CMD ["/usr/local/bin/start-notebook.sh"]
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,7 @@ RUN set -ex; \
     apt-get clean; \
     rm -rf /var/tmp/* /tmp/* /var/lib/apt/lists/*
 
-COPY root/usr/local/bin /usr/local/bin
-COPY root/etc/jupyter /etc/jupyter
-COPY root/docker-entrypoint.sh /docker-entrypoint.sh
+COPY root/* /
 
 CMD ["/usr/local/bin/start-notebook.sh"]
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
The phishing notebook image was breaking because it couldn't install git-lfs. Replacing the folders in / broke some apt-get functionality.